### PR TITLE
Fixed .highlighted to have more padding

### DIFF
--- a/_sass/sassline-base/_typography.scss
+++ b/_sass/sassline-base/_typography.scss
@@ -70,7 +70,7 @@ a {
     //text highlight
     .highlighted {
         background-color: rgba(0,0,0,0.5);
-        padding: 0px;
+        padding: 10px;
     }
 
     //white text

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -2,5 +2,11 @@
 title: false
 styles: true
 ---
+.typeset {
+    .highlighted {
+        background-color: rgba(0,0,0,0.5);
+	padding: 10px;
+    }
+}
 
 @import "alembic";


### PR DESCRIPTION
The highlighted portion on the "header" part should now have more padding.